### PR TITLE
Remove reference to vasypd in init script for SuSE

### DIFF
--- a/build-nrpe-2.15.sh
+++ b/build-nrpe-2.15.sh
@@ -9,7 +9,7 @@ SANDBOX=$PKGDIR/sandbox-nrpe
 scriptname=${0##*/}
 scriptdir=${0%/*}
 
-packagerel=2
+packagerel=3
 nrpe_user=op5nrpe
 nrpe_user_solaris=op5nrpe
 nrpe_uid=95118

--- a/nrpe-initscript.sh
+++ b/nrpe-initscript.sh
@@ -118,9 +118,9 @@ cat << EOSUSE
 #
 ### BEGIN INIT INFO
 # Provides:          nagios-nrpe
-# Required-Start:    \$remote_fs \$syslog \$network vasypd
+# Required-Start:    \$remote_fs \$syslog \$network
 # Should-Start:      cron
-# Required-Stop:     \$remote_fs \$syslog vasypd
+# Required-Stop:     \$remote_fs \$syslog
 # Should-Stop:       cron
 # Default-Start:     3 5
 # Default-Stop:      0 1 2 6


### PR DESCRIPTION
Redmine #316 puppet module nrpe - enable nrpe service on SuSE without vasypd
